### PR TITLE
Added Go modules support.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/iowar/poloniex
+
+go 1.12
+
+require (
+	github.com/gorilla/websocket v1.4.0
+	github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
+github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24 h1:pntxY8Ary0t43dCZ5dqY4YTJCObLY1kIXl0uzMv+7DE=
+github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=


### PR DESCRIPTION
Proposing to add Go modules support to `github.com/iowar/poloniex`, which would bring it up to code with standard package management practices for Go libraries. You can read about Go modules [here](https://github.com/golang/go/wiki/Modules).

To use Go modules, consumers would need to use Go 1.11+.

Also, for best results, I would recommend tagging the master branch with a semver-compatible version tag, such as `v1.0.0` so that Go modules can properly resolve releases.